### PR TITLE
Add delete cascade to joins 

### DIFF
--- a/Database.sql
+++ b/Database.sql
@@ -102,7 +102,7 @@ CREATE TABLE joins(
     session_time TIME,
     CONSTRAINT joins_pk PRIMARY KEY(eid,room,building_floor,session_date,session_time),
     CONSTRAINT joins_employee_fk_constraint FOREIGN KEY (eid) REFERENCES employees(eid),
-    CONSTRAINT joins_meeting_sessions_fk_constraint FOREIGN KEY (room,building_floor,session_date,session_time) REFERENCES meeting_sessions(room,building_floor,session_date,session_time),
+    CONSTRAINT joins_meeting_sessions_fk_constraint FOREIGN KEY (room,building_floor,session_date,session_time) REFERENCES meeting_sessions(room,building_floor,session_date,session_time) ON DELETE CASCADE,
     CONSTRAINT valid_meeting_entry CHECK(session_date > CURRENT_DATE OR (session_date = CURRENT_DATE AND session_time > CURRENT_TIME))
 );
 


### PR DESCRIPTION
Regarding constraint: **If the employee is the one booking the room, the booking is cancelled, approved or not.**
(PR #11 )
added cascade so this flow will occur when an employee has fever trigger is called, lmk if it doesnt makes sense/has other implications! i rmbr prof said we shld be wary of using delete cascade cux we may not be able to retrieve lost data.
deleted booking -> deleted meeting session -> deleted joins entry